### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -234,11 +234,11 @@ With all the correct guards and logic setup, it's time to specify the correct op
       # --format documentation : for better output
       # :spec_paths to pass the correct path to look for features
       guard :rspec, :version => 2, :cli => "--color --format documentation", :spec_paths => ["puppet-repo"]  do
-        # Match any .pp file (but be carefull not to include any dot-temporary files)
+        # Match any .pp file (but be careful not to include any dot-temporary files)
         watch(%r{^puppet-repo/.*/[^.]*\.pp$}) { "puppet-repo" }
-        # Match any .rb file (but be carefull not to include any dot-temporary files)
+        # Match any .rb file (but be careful not to include any dot-temporary files)
         watch(%r{^puppet-repo/.*/[^.]*\.rb$}) { "puppet-repo" }
-        # Match any _rspec.rb file (but be carefull not to include any dot-temporary files)
+        # Match any _rspec.rb file (but be careful not to include any dot-temporary files)
         watch(%r{^puppet-repo/.*/[^.]*_rspec.rb})
       end
 
@@ -248,10 +248,10 @@ With all the correct guards and logic setup, it's time to specify the correct op
       # --format pretty : to get readable output, default is null output
       guard :extendedcucumber, :cli => "--require puppet-repo/features --strict --format pretty" do
 
-        # Match any .pp file (but be carefull not to include any dot-temporary files)
+        # Match any .pp file (but be careful not to include any dot-temporary files)
         watch(%r{^puppet-repo/[^.]*\.pp$}) { "puppet-repo/features" }
 
-        # Match any .rb file (but be carefull not to include any dot-temporary files)
+        # Match any .rb file (but be careful not to include any dot-temporary files)
         watch(%r{^puppet-repo/[^.]*\.rb$}) { "puppet-repo/features" }
 
         # Feature files are monitored as well


### PR DESCRIPTION
@jedi4ever, I've corrected a typographical error in the documentation of the [vagrant-guard-demo](https://github.com/jedi4ever/vagrant-guard-demo) project. Specifically, I've changed carefull to careful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
